### PR TITLE
generate-stackbrew-library.sh: Fix detection of deleted files in COPY command

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -26,17 +26,18 @@ fileCommit() {
 # get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
 dirCommit() {
 	local dir="$1"; shift
+	local copyPaths;
 	(
 		cd "$dir"
-		fileCommit \
-			Dockerfile \
-			$(git show HEAD:./Dockerfile | awk '
-				toupper($1) == "COPY" {
-					for (i = 2; i < NF; i++) {
-						print $i
-					}
+		IFS=" " read -r -a copyPaths <<< "$(git show HEAD:./Dockerfile | awk '
+			BEGIN { ORS=" "; }
+			toupper($1) == "COPY" {
+				for (i = 2; i < NF; i++) {
+					print $i
 				}
-			')
+			}
+		')"
+		fileCommit Dockerfile "${copyPaths[@]}"
 	)
 }
 


### PR DESCRIPTION
Don't let the shell do glob expansion, because it would not find deleted files. `git` can.