### PR TITLE
Update Varnish 6.0 (LTS) and 6.2 versions

### DIFF
--- a/6.0/alpine3.8/Dockerfile
+++ b/6.0/alpine3.8/Dockerfile
@@ -29,9 +29,9 @@ RUN apk add --no-cache --virtual .persistent-deps \
 		libc-dev \
 		libgcc
 
-ENV VARNISH_VERSION 6.0.3
-ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.0.3.tgz
-ENV VARNISH_SHA256 4e0a4803b54726630719a22e79a2c5b36876506497e24fb39a47e9df219778d7
+ENV VARNISH_VERSION 6.0.6
+ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.0.6.tgz
+ENV VARNISH_SHA256 298476eaea36109845a7640fa578bf8a8a04124d2f1c9bc75e1d6ae2bd760b4a
 
 COPY *.patch /varnish-alpine-patches/
 

--- a/6.0/stretch/Dockerfile
+++ b/6.0/stretch/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get update && apt-get install -y \
 		libc6-dev \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
-ENV VARNISH_VERSION 6.0.3
-ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.0.3.tgz
-ENV VARNISH_SHA256 4e0a4803b54726630719a22e79a2c5b36876506497e24fb39a47e9df219778d7
+ENV VARNISH_VERSION 6.0.6
+ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.0.6.tgz
+ENV VARNISH_SHA256 298476eaea36109845a7640fa578bf8a8a04124d2f1c9bc75e1d6ae2bd760b4a
 
 RUN set -eux; \
 	\

--- a/6.2/alpine3.8/Dockerfile
+++ b/6.2/alpine3.8/Dockerfile
@@ -29,9 +29,9 @@ RUN apk add --no-cache --virtual .persistent-deps \
 		libc-dev \
 		libgcc
 
-ENV VARNISH_VERSION 6.2.0
-ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.2.0.tgz
-ENV VARNISH_SHA256 c37af353aca25a83d22f9c5ce0ae800fe433e4d02e1457e02886a5849f988e53
+ENV VARNISH_VERSION 6.2.3
+ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.2.3.tgz
+ENV VARNISH_SHA256 5ecbd05e345e7f7ef0082b916edab3597ee9962058102bccb0a4055920be6609
 
 COPY *.patch /varnish-alpine-patches/
 

--- a/6.2/stretch/Dockerfile
+++ b/6.2/stretch/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get update && apt-get install -y \
 		libc6-dev \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
-ENV VARNISH_VERSION 6.2.0
-ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.2.0.tgz
-ENV VARNISH_SHA256 c37af353aca25a83d22f9c5ce0ae800fe433e4d02e1457e02886a5849f988e53
+ENV VARNISH_VERSION 6.2.3
+ENV VARNISH_URL https://varnish-cache.org/_downloads/varnish-6.2.3.tgz
+ENV VARNISH_SHA256 5ecbd05e345e7f7ef0082b916edab3597ee9962058102bccb0a4055920be6609
 
 RUN set -eux; \
 	\


### PR DESCRIPTION
This updates to the 6.0.4 and 6.2.1 versions of Varnish, which address the VSV00003 DoS attack vector (CVE-2019-15892).

More info here: [https://varnish-cache.org/security/VSV00003.html](https://varnish-cache.org/security/VSV00003.html)